### PR TITLE
f-centos-7 - Support for cheaper CentOS 7/t3 instances, visibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ This contains HashiCorp code to do the following:
 6. Execute Packer build
 ```
 cd packer
-packer build -var-file=vars.json -only=amazon-ebs-rhel-7.5-systemd  packer.json   
+# CentOS 7(default)
+packer build -var-file=vars.json -only=amazon-ebs-centos-7 packer.json   
+# RHEL 7.5 - Additional licensing costs
+packer build -var-file=vars.json -only=amazon-ebs-rhel-7.5-systemd packer.json   
 ```
 
 ## Terraform usage

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -15,7 +15,7 @@
       "force_deregister": true,
       "force_delete_snapshot": true,
       "ssh_pty": true,
-      "instance_type": "t2.medium",
+      "instance_type": "t3.medium",
       "associate_public_ip_address": true,
       "source_ami_filter": {
         "filters": {
@@ -41,6 +41,45 @@
         "Nomad-Version": "{{ user `nomad_version` }}",
         "OS": "rhel",
         "OS-Version": "7.5",
+        "Release": "{{ user `release` }}"
+      }
+    },
+    {
+      "name": "amazon-ebs-centos-7",
+      "type": "amazon-ebs",
+      "access_key": "{{ user `aws_access_key_id` }}",
+      "secret_key": "{{ user `aws_secret_access_key` }}",
+      "region": "{{ user `aws_region` }}",
+      "spot_price": "0",
+      "force_deregister": true,
+      "force_delete_snapshot": true,
+      "ssh_pty": true,
+      "instance_type": "t3.medium",
+      "associate_public_ip_address": true,
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "*CentOS Linux 7 x86_64 HVM EBS ENA*",
+          "root-device-type": "ebs"
+        },
+        "owners": ["679593333241"],
+        "most_recent": true
+      },
+      "ssh_username": "centos",
+      "ssh_timeout": "5m",
+      "ami_virtualization_type": "hvm",
+      "ami_name": "hashistack-image-centos7-{{isotime \"2006-01-02-03-04\"}}",
+      "ami_description": "HashiStack Image - CentOS 7",
+      "ami_regions": ["us-east-1", "us-east-2", "us-west-2"],
+      "tags": {
+        "Name": "HashiStack CentOS 7 Image {{ user `release_version` }}: Consul v{{ user `consul_version` }} Vault v{{ user `vault_version` }} Nomad v{{ user `nomad_version` }}",
+        "System": "HashiStack",
+        "Product": "HashiStack",
+        "Consul-Version": "{{ user `consul_version` }}",
+        "Vault-Version": "{{ user `vault_version` }}",
+        "Nomad-Version": "{{ user `nomad_version` }}",
+        "OS": "centos",
+        "OS-Version": "7",
         "Release": "{{ user `release` }}"
       }
     },
@@ -178,6 +217,16 @@
       "type": "shell",
       "script": "scripts/rhel.sh",
       "only": ["amazon-ebs-rhel-7.5-systemd"]
+    },
+    {
+      "type": "shell",
+      "script": "scripts/centos-7.sh",
+      "only": ["amazon-ebs-centos-7"]
+    },
+    {
+      "type": "shell",
+      "script": "scripts/el7.sh",
+      "only": ["amazon-ebs-rhel-7.5-systemd","amazon-ebs-centos7"]
     },
     {
       "type": "shell",

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -226,7 +226,7 @@
     {
       "type": "shell",
       "script": "scripts/el7.sh",
-      "only": ["amazon-ebs-rhel-7.5-systemd","amazon-ebs-centos7"]
+      "only": ["amazon-ebs-rhel-7.5-systemd","amazon-ebs-centos-7"]
     },
     {
       "type": "shell",

--- a/packer/scripts/centos-7.sh
+++ b/packer/scripts/centos-7.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -x
+
+# Centos7 Specific Setup Here

--- a/packer/scripts/el7.sh
+++ b/packer/scripts/el7.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -x
+
+echo "Installing updates and pre-requisites...."
+sudo yum -y check-update
+sudo rpm -Uvh http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
+sudo yum install -q -y wget unzip dnsmasq bind-utils ruby rubygems \
+  ntp git ca-certificates vim-enhanced haproxy nginx
+sudo systemctl start ntpd.service
+sudo systemctl enable ntpd.service
+sudo systemctl stop firewalld.service
+sudo systemctl disable firewalld.service
+curl --silent -O https://bootstrap.pypa.io/get-pip.py
+sudo python get-pip.py
+sudo pip install awscli
+echo "Adding Consul and Vault system users"
+  # RHEL user setup
+for _user in consul consul-template vault; do
+  sudo /usr/sbin/groupadd --force --system ${_user}
+  if ! getent passwd ${_user} >/dev/null ; then
+    sudo /usr/sbin/adduser \
+      --system \
+      --gid ${_user} \
+      --home /srv/${_user} \
+      --no-create-home \
+      --comment "${_user} account" \
+      --shell /bin/false \
+      ${_user}  >/dev/null
+  fi
+done
+
+echo "Installing Docker with RHEL Workaround"
+sudo yum -yq install policycoreutils-python yum-utils device-mapper-persistent-data lvm2
+sudo yum -y remove docker docker-client docker-client-latest docker-common docker-latest \
+  docker-latest-logrotate docker-logrotate docker-selinux docker-engine-selinux \
+  docker-engine container-selinux
+sudo yum-config-manager -y --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum install -y --setopt=obsoletes=0 \
+  docker-ce-18.06.1.ce-3.el7.x86_64

--- a/packer/scripts/rhel.sh
+++ b/packer/scripts/rhel.sh
@@ -1,42 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
-echo "Performing updates and installing prerequisites"
+echo "Enabling RHEL repos...."
 sudo yum-config-manager --enable rhui-REGION-rhel-server-releases-optional
 sudo yum-config-manager --enable rhui-REGION-rhel-server-supplementary
 sudo yum-config-manager --enable rhui-REGION-rhel-server-extras
-sudo yum -y check-update
-sudo rpm -Uvh http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
-sudo yum install -q -y wget unzip dnsmasq bind-utils ruby rubygems \
-  ntp git ca-certificates vim-enhanced haproxy nginx
-sudo systemctl start ntpd.service
-sudo systemctl enable ntpd.service
-sudo systemctl stop firewalld.service
-sudo systemctl disable firewalld.service
-curl --silent -O https://bootstrap.pypa.io/get-pip.py
-sudo python get-pip.py
-sudo pip install awscli
-echo "Adding Consul and Vault system users"
-  # RHEL user setup
-for _user in consul consul-template vault; do
-  sudo /usr/sbin/groupadd --force --system ${_user}
-  if ! getent passwd ${_user} >/dev/null ; then
-    sudo /usr/sbin/adduser \
-      --system \
-      --gid ${_user} \
-      --home /srv/${_user} \
-      --no-create-home \
-      --comment "${_user} account" \
-      --shell /bin/false \
-      ${_user}  >/dev/null
-  fi
-done
-
-echo "Installing Docker with RHEL Workaround"
-sudo yum -yq install policycoreutils-python yum-utils device-mapper-persistent-data lvm2
-sudo yum -y remove docker docker-client docker-client-latest docker-common docker-latest \
-  docker-latest-logrotate docker-logrotate docker-selinux docker-engine-selinux \
-  docker-engine container-selinux
-sudo yum-config-manager -y --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum install -y --setopt=obsoletes=0 \
-  docker-ce-18.06.1.ce-3.el7.x86_64

--- a/packer/scripts/setup.sh
+++ b/packer/scripts/setup.sh
@@ -10,7 +10,14 @@ sudo curl --silent -Lo /bin/jq https://github.com/stedolan/jq/releases/download/
 sudo chmod +x /bin/jq
 
 echo "Configuring Docker options and service"
-sudo sh -c "echo \"DOCKER_OPTS='--dns 127.0.0.1 --dns 8.8.8.8 --dns-search service.consul'\" >> /etc/default/docker"
+sudo mkdir /etc/docker && sudo chmod 700 /etc/docker
+sudo bash -c "cat >/etc/docker/daemon.json" << EOF
+{
+  "bip": "172.17.0.1/16",
+  "dns": [ "172.17.0.1", "8.8.8.8" ],
+  "dns-search": [ "service.consul" ]
+}
+EOF
 
 sudo systemctl enable docker
 sudo systemctl start docker

--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -56,6 +56,7 @@ resource "aws_instance" "admin" {
   }
 
   tags {
+    Name             = "${var.cluster_name} - admin"
     Environment-Name = "${var.environment_name}"
     role             = "admin"
     owner            = "${var.owner}"

--- a/terraform/aviato/main.tf
+++ b/terraform/aviato/main.tf
@@ -30,7 +30,7 @@ resource "aws_key_pair" "main" {
 
 resource "aws_instance" "haproxy" {
   ami               = "${data.aws_ami.hashistack.id}"
-  instance_type     = "t2.small"
+  instance_type     = "t3.small"
   count             = 1
   subnet_id         = "${var.subnet_ids[0]}"
   key_name          = "${var.ssh_key_name}"
@@ -45,6 +45,7 @@ resource "aws_instance" "haproxy" {
   iam_instance_profile        = "${var.instance_profile}"
 
   tags {
+    Name             = "${var.cluster_name} - haproxy"
     Environment-Name = "${var.environment_name}"
     role             = "haproxy"
     owner            = "${var.owner}"
@@ -87,7 +88,7 @@ resource "aws_security_group" "haproxy" {
 
 resource "aws_instance" "nginx" {
   ami               = "${data.aws_ami.hashistack.id}"
-  instance_type     = "t2.small"
+  instance_type     = "t3.small"
   count             = "${var.nginx_count}"
   subnet_id         = "${var.subnet_ids[0]}"
   key_name          = "${var.ssh_key_name}"
@@ -102,6 +103,7 @@ resource "aws_instance" "nginx" {
   iam_instance_profile        = "${var.instance_profile}"
 
   tags {
+    Name             = "${var.cluster_name} - nginx"
     Environment-Name = "${var.environment_name}"
     role             = "nginx"
     owner            = "${var.owner}"

--- a/terraform/aviato/variables.tf
+++ b/terraform/aviato/variables.tf
@@ -21,18 +21,18 @@ variable "instance_type" {
 }
 
 variable "operating_system" {
-  default     = "rhel"
-  description = "Operating system type, supported options are rhel and ubuntu"
+  default     = "centos"
+  description = "Operating system type, supported options are rhel, centos, and ubuntu"
 }
 
 variable "operating_system_version" {
-  default     = "7.3"
-  description = "Operating system version, supported options are 7.3 for rhel, 16.04 for ubuntu"
+  default     = "7"
+  description = "Operating system version, supported options are 7.5 for rhel, 7 for CentOS, 16.04/18.04 for ubuntu"
 }
 
 variable "ssh_user_name" {
-  default     = "ec2-user"
-  description = "Default ssh username for provisioning, ec2-user for rhel systems, ubuntu for ubuntu systems"
+  default     = "centos"
+  description = "Default ssh username for provisioning, ec2-user for rhel systems, centos for CentOS systems, ubuntu for ubuntu systems"
 }
 
 variable "vanity_domain" {

--- a/terraform/client/init-client.tpl
+++ b/terraform/client/init-client.tpl
@@ -5,7 +5,7 @@ exec 1> >(logger -s -t $(basename $0)) 2>&1
 instance_id="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
 local_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 public_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)"
-new_hostname="hashistack-$${instance_id}"
+new_hostname="hashistack-client"
 
 echo "${private_key}" > /home/${ssh_user_name}/.ssh/id_rsa
 chmod 0700 /home/${ssh_user_name}/.ssh

--- a/terraform/client/main.tf
+++ b/terraform/client/main.tf
@@ -40,6 +40,7 @@ resource "aws_instance" "client" {
   iam_instance_profile        = "${var.instance_profile}"
 
   tags {
+    Name             = "${var.cluster_name} - client"
     Environment-Name = "${var.environment_name}"
     role             = "client"
     owner            = "${var.owner}"

--- a/terraform/client/variables.tf
+++ b/terraform/client/variables.tf
@@ -8,13 +8,8 @@ variable "region" {}
 variable "instance_profile" {}
 variable "owner" {}
 variable "ttl" {}
-variable "image_release" {}
 
 variable "subnet_ids" {
-  type = "list"
-}
-
-variable "remote_regions" {
   type = "list"
 }
 
@@ -23,22 +18,8 @@ variable "instance_type" {
   description = "AWS instance type to use eg m4.large"
 }
 
-variable "aws_auth_access_key" {
-  type        = "string"
-  description = "AWS access key used by Vault to validate AWS authentication attempts"
-}
-
-variable "aws_auth_secret_key" {
-  type        = "string"
-  description = "AWS secret key used by Vault to validate AWS authentication attempts"
-}
-
 variable "hashistack_instance_arn" {
   description = "AWS IAM role ARN value for Hashistack node"
-}
-
-variable "aviato_instance_arn" {
-  description = "AWS IAM role ARN value for aviato node"
 }
 
 variable "operating_system" {
@@ -56,14 +37,8 @@ variable "ssh_user_name" {
   description = "Default ssh username for provisioning, ec2-user for rhel systems, ubuntu for ubuntu systems"
 }
 
-variable "vault_cloud_auto_init_and_unseal" {
-  type        = "string"
-  description = "Enable or disable automatic Vault initialization and unseal. True or false, string."
-}
-
-variable "vault_auto_replication_setup" {
-  type        = "string"
-  description = "Enable or disable automatic replication configuration between Vault clusters. True or false, string."
+output "ssh_info" {
+  value = "${data.template_file.format_ssh.rendered}"
 }
 
 variable "vanity_domain" {

--- a/terraform/hashistack/init-cluster.tpl
+++ b/terraform/hashistack/init-cluster.tpl
@@ -6,7 +6,7 @@ instance_id="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
 availability_zone="$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)"
 local_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 public_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)"
-new_hostname="hashistack-$${public_ipv4}"
+new_hostname="hashistack-cluster-$${local_ipv4}"
 
 echo "${private_key}" > /home/${ssh_user_name}/.ssh/id_rsa
 chmod 0700 /home/${ssh_user_name}/.ssh

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,7 +82,7 @@ module "vpc-west" {
 }
 
 locals {
-  ssh_user_map = "${map("ubuntu","ubuntu","rhel","ec2-user")}"
+  ssh_user_map = "${map("ubuntu","ubuntu","rhel","ec2-user","centos","centos")}"
 }
 
 module "hashistack-us-east" {
@@ -163,6 +163,7 @@ module "client-west" {
   owner                            = "${var.owner}"
   ttl                              = "${var.ttl}"
   region                           = "us-west-2"
+  cluster_name                     = "${random_id.environment_name.hex}-us-west-2"
   environment_name                 = "${random_id.environment_name.hex}"
   ssh_key_name                     = "${random_id.environment_name.hex}-client"
   instance_profile                 = "${module.hashistack-instance-profile.policy}"

--- a/terraform/mysql-database/database.tpl
+++ b/terraform/mysql-database/database.tpl
@@ -3,7 +3,7 @@
 instance_id="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
 local_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 public_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)"
-new_hostname="hashistack-$${instance_id}"
+new_hostname="hashistack-db-$${public_ipv4}"
 
 echo "${private_key}" > /home/${ssh_user_name}/.ssh/id_rsa
 chmod 0700 /home/${ssh_user_name}/.ssh

--- a/terraform/mysql-database/main.tf
+++ b/terraform/mysql-database/main.tf
@@ -30,7 +30,7 @@ resource "aws_key_pair" "main" {
 
 resource "aws_instance" "db" {
   ami               = "${data.aws_ami.hashistack.id}"
-  instance_type     = "t2.small"
+  instance_type     = "t3.small"
   count             = 1
   subnet_id         = "${var.subnet_ids[0]}"
   key_name          = "${var.ssh_key_name}"
@@ -45,6 +45,7 @@ resource "aws_instance" "db" {
   iam_instance_profile        = "${var.instance_profile}"
 
   tags {
+    Name             = "${var.cluster_name} - mysql-database"
     Environment-Name = "${var.environment_name}"
     role             = "database"
     owner            = "${var.owner}"

--- a/terraform/mysql-database/variables.tf
+++ b/terraform/mysql-database/variables.tf
@@ -6,7 +6,6 @@ variable "environment_name" {}
 variable "cluster_name" {}
 variable "region" {}
 variable "instance_profile" {}
-variable "kms_id" {}
 variable "owner" {}
 variable "ttl" {}
 variable "image_release" {}
@@ -15,18 +14,9 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "public_subnet_ids" {
-  type = "list"
-}
-
-variable "cluster_size" {
-  default     = "3"
-  description = "Number of instances to launch in the cluster"
-}
-
 variable "instance_type" {
-  default     = "t3.large"
-  description = "AWS instance type to use"
+  default     = "t2.micro"
+  description = "AWS instance type to use eg m4.large"
 }
 
 variable "operating_system" {
@@ -36,19 +26,19 @@ variable "operating_system" {
 
 variable "operating_system_version" {
   default     = "7"
-  description = "Operating system version, supported options are 7.5 for rhel, 7 for centos, 16.04/18.04 for ubuntu"
+  description = "Operating system version, supported options are 7.5 for rhel, 7 for CentOS, 16.04/18.04 for ubuntu"
 }
 
 variable "ssh_user_name" {
   default     = "centos"
-  description = "Default ssh username for provisioning, ec2-user for rhel systems, ubuntu for ubuntu systems"
-}
-
-variable "remote_regions" {
-  type = "list"
+  description = "Default ssh username for provisioning, ec2-user for rhel systems, centos for CentOS systems, ubuntu for ubuntu systems"
 }
 
 variable "vanity_domain" {
   default     = "none"
   description = "Vanity domain name to use"
+}
+
+output "db_address" {
+  value = "${var.vanity_domain == "none" ? "${aws_instance.db.public_ip}" : "${element(concat(aws_route53_record.db.*.name, list("")), 0)}"}"
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -2,9 +2,13 @@ owner    = "John Doe"
 ttl      = "24"
 env_name = "hashistack"
 
-# rhel option
-operating_system           = "rhel"
-operating_system_version   = "7.5"
+# centos option
+operating_system           = "centos"
+operating_system_version   = "7"
+
+# rhel option - additional instance licensing costs
+#operating_system           = "rhel"
+#operating_system_version   = "7.5"
 
 # ubuntu option - work in progress
 #operating_system           = "ubuntu"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,17 +32,17 @@ variable "vault_auto_replication_setup" {
 }
 
 variable "operating_system" {
-  default     = "rhel"
-  description = "Operating system type, supported options are rhel and ubuntu"
+  default     = "centos"
+  description = "Operating system type, supported options are rhel, centos, and ubuntu"
 }
 
 variable "operating_system_version" {
-  default     = "7.5"
-  description = "Operating system version, supported options are 7.3 for rhel, 16.04 for ubuntu"
+  default     = "7"
+  description = "Operating system version, supported options are 7.5 for rhel, 7 for CentOS, 16.04/18.04 for ubuntu"
 }
 
 variable "ssh_user_name" {
-  default     = "ec2-user"
+  default     = "centos"
   description = "Default ssh username for provisioning, ec2-user for rhel systems, ubuntu for ubuntu systems"
 }
 


### PR DESCRIPTION
Adding support for CentOS 7(cheaper), moved to t3 instances(cheaper) for everything that wasn't t2.micro(free-tier), hostnaming/display name visibility improvements.

RHEL7.5 vs. CentOS 7(rolling releases currently 1805 7.5) - T2 vs. T3
RHEL        - t2.micro - 1vcpu 1GB - $0.0716 per Hour
CentOS 7 - t2.micro - 1vcpu 1GB - $0.0116 per Hour(free-tier 750 hrs/month)
RHEL        - t2.small - 1vcpu 2GB - $0.083 per Hour
CentOS 7 - t2.small  - 1vcpu 2GB - $0.023 per Hour
RHEL        - t3.small - 2vcpu 2GB - $0.0808 per Hour
CentOS 7 - t3.small - 2vcpu 2GB - $0.0208 per Hour
RHEL        - t2.large - 2vcpu 8GB - $0.1528 per Hour
CentOS 7 - t2.large - 2vcpu 8GB - $0.0928 per Hour
RHEL        - t3.large - 2vcpu 8GB - $0.1432 per Hour
CentOS 7 - t3.large - 2vcpu 8GB - $0.0832 per Hour

RHEL 7x and CentOS 7 are generally functionally equivalent and there are rarely cross-compatibility issues.  T3 are a bit faster performance and slightly cheaper.  Will work on Ubuntu in a separate PR.