### PR TITLE
Update maria db

### DIFF
--- a/terraform/admin/init-admin.tpl
+++ b/terraform/admin/init-admin.tpl
@@ -37,14 +37,14 @@ systemctl daemon-reload
 while [ "x$${consul_leader_http_code}" != "x200" ] ; do
   echo "Waiting for Consul to get a leader..."
   sleep 5
-  consul_leader_http_code=$(curl --silent --output /dev/null --write-out "%{http_code}" "http://127.0.0.1:8500/v1/operator/raft/configuration") || consul_leader_http_code=""
+  consul_leader_http_code=$(curl --silent --output /dev/null --write-out "%%{http_code}" "http://127.0.0.1:8500/v1/operator/raft/configuration") || consul_leader_http_code=""
 done
 
 for region in ${remote_regions}; do
   while [ "x$${wan_consul_leader_http_code}" != "x200" ] ; do
     echo "Waiting for Consul WAN join to $${region} to complete..."
     sleep 5
-    wan_consul_leader_http_code=$(curl --silent --output /dev/null --write-out "%{http_code}" "http://127.0.0.1:8500/v1/operator/raft/configuration?dc=$${region}") || consul_leader_http_code=""
+    wan_consul_leader_http_code=$(curl --silent --output /dev/null --write-out "%%{http_code}" "http://127.0.0.1:8500/v1/operator/raft/configuration?dc=$${region}") || consul_leader_http_code=""
   done
 done
 

--- a/terraform/mysql-database/database.tpl
+++ b/terraform/mysql-database/database.tpl
@@ -41,6 +41,14 @@ cat <<EOF>> /etc/consul.d/consul.json
 EOF
 chown consul:consul /etc/consul.d/consul.json
 
+cat <<EOF>> /etc/yum.repos.d/MariaDB.repo
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.3/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOF
+
 
 # Detect package management system.
 YUM=$(which yum 2>/dev/null)


### PR DESCRIPTION
Updated to support MariaDB 10.3, which required an update to the MariaDB repos. This has been tested and works deploying with TFE.